### PR TITLE
Add Host Rank System, Upgrade Version Compatibility, and Expand Configuration Options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
 
     <groupId>net.vertrauterdavid</groupId>
     <artifactId>EventCore</artifactId>
-    <version>1.5</version>
+    <version>1.6</version>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -29,13 +29,13 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>1.18.30</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.19.2-R0.1-SNAPSHOT</version>
+            <version>1.21.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/net/vertrauterdavid/EventCore.java
+++ b/src/main/java/net/vertrauterdavid/EventCore.java
@@ -1,6 +1,7 @@
 package net.vertrauterdavid;
 
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.vertrauterdavid.command.*;
@@ -16,6 +17,7 @@ import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 
+@Slf4j
 @Getter
 public class EventCore extends JavaPlugin {
 
@@ -40,6 +42,7 @@ public class EventCore extends JavaPlugin {
         new EventCommand("e");
         new KitCommand("kit");
         new ReviveCommand("revive");
+        new ReviveCommand("respawn");
         new SpawnCommand("spawn");
 
         Bukkit.getPluginManager().registerEvents(new BlockBreakListener(), instance);

--- a/src/main/java/net/vertrauterdavid/command/AnnoucementCommand.java
+++ b/src/main/java/net/vertrauterdavid/command/AnnoucementCommand.java
@@ -9,10 +9,12 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
+
 public class AnnoucementCommand implements CommandExecutor {
 
     public AnnoucementCommand(String name) {
-        EventCore.getInstance().getCommand(name).setExecutor(this);
+        Objects.requireNonNull(EventCore.getInstance().getCommand(name)).setExecutor(this);
     }
 
     @Override

--- a/src/main/java/net/vertrauterdavid/command/EventCommand.java
+++ b/src/main/java/net/vertrauterdavid/command/EventCommand.java
@@ -6,21 +6,24 @@ import net.vertrauterdavid.util.MessageUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Sound;
-import org.bukkit.command.*;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class EventCommand implements CommandExecutor, TabCompleter {
 
     public EventCommand(String name) {
-        EventCore.getInstance().getCommand(name).setExecutor(this);
-        EventCore.getInstance().getCommand(name).setTabCompleter(this);
+        Objects.requireNonNull(EventCore.getInstance().getCommand(name)).setExecutor(this);
+        Objects.requireNonNull(EventCore.getInstance().getCommand(name)).setTabCompleter(this);
     }
 
     @Override
@@ -29,7 +32,7 @@ public class EventCommand implements CommandExecutor, TabCompleter {
 
         if (args.length == 0) {
             player.sendMessage(" ");
-            player.sendMessage(MessageUtil.getPrefix() + "§7Running §aEventCore §7v" + EventCore.getInstance().getVersionUtil().getCurrentVersion(EventCore.getInstance()));
+            player.sendMessage(MessageUtil.getPrefix() + "§7Running §aEventCore §7v" + EventCore.getInstance().getDescription().getVersion());
             player.sendMessage(MessageUtil.getPrefix() + "§7Download at §ahttps://github.com/VertrauterDavid");
             player.sendMessage(" ");
         }

--- a/src/main/java/net/vertrauterdavid/command/EventCommand.java
+++ b/src/main/java/net/vertrauterdavid/command/EventCommand.java
@@ -101,14 +101,14 @@ public class EventCommand implements CommandExecutor, TabCompleter {
         if (args.length == 2) {
             if (args[0].equalsIgnoreCase("autoBorder")) {
                 if (args[1].equalsIgnoreCase("on")) {
-                    BorderUtil.autoBorder = true;
+                    BorderUtil.setAutoBorder(true);
 
                     player.sendMessage(MessageUtil.getPrefix() + "AutoBorder has been §aactivated!");
                     return false;
                 }
 
                 if (args[1].equalsIgnoreCase("off")) {
-                    BorderUtil.autoBorder = false;
+                    BorderUtil.setAutoBorder(false);
                     BorderUtil.lastOptimal = BorderUtil.borderDefault;
 
                     player.sendMessage(MessageUtil.getPrefix() + "AutoBorder has been §cdeactivated!");

--- a/src/main/java/net/vertrauterdavid/command/KitCommand.java
+++ b/src/main/java/net/vertrauterdavid/command/KitCommand.java
@@ -13,12 +13,13 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class KitCommand implements CommandExecutor, TabCompleter {
 
     public KitCommand(String name) {
-        EventCore.getInstance().getCommand(name).setExecutor(this);
-        EventCore.getInstance().getCommand(name).setTabCompleter(this);
+        Objects.requireNonNull(EventCore.getInstance().getCommand(name)).setExecutor(this);
+        Objects.requireNonNull(EventCore.getInstance().getCommand(name)).setTabCompleter(this);
     }
 
     @Override

--- a/src/main/java/net/vertrauterdavid/command/ReviveCommand.java
+++ b/src/main/java/net/vertrauterdavid/command/ReviveCommand.java
@@ -15,12 +15,13 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class ReviveCommand implements CommandExecutor, TabCompleter {
 
     public ReviveCommand(String name) {
-        EventCore.getInstance().getCommand(name).setExecutor(this);
-        EventCore.getInstance().getCommand(name).setTabCompleter(this);
+        Objects.requireNonNull(EventCore.getInstance().getCommand(name)).setExecutor(this);
+        Objects.requireNonNull(EventCore.getInstance().getCommand(name)).setTabCompleter(this);
     }
 
     @Override

--- a/src/main/java/net/vertrauterdavid/command/SpawnCommand.java
+++ b/src/main/java/net/vertrauterdavid/command/SpawnCommand.java
@@ -7,10 +7,12 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
+
 public class SpawnCommand implements CommandExecutor {
 
     public SpawnCommand(String name) {
-        EventCore.getInstance().getCommand(name).setExecutor(this);
+        Objects.requireNonNull(EventCore.getInstance().getCommand(name)).setExecutor(this);
     }
 
     @Override

--- a/src/main/java/net/vertrauterdavid/listener/EntityDamageByEntityListener.java
+++ b/src/main/java/net/vertrauterdavid/listener/EntityDamageByEntityListener.java
@@ -16,7 +16,7 @@ public class EntityDamageByEntityListener implements Listener {
         Entity damager = event.getDamager();
 
         if (EventCore.getInstance().getConfig().getBoolean("Settings.DisableItemExplosions", true)) {
-            if (entity.getType() == EntityType.DROPPED_ITEM && damager.getType() == EntityType.ENDER_CRYSTAL) {
+            if (entity.getType() == EntityType.ITEM && damager.getType() == EntityType.END_CRYSTAL) {
                 if (event.getCause() == EntityDamageEvent.DamageCause.ENTITY_EXPLOSION || event.getCause() == EntityDamageEvent.DamageCause.BLOCK_EXPLOSION) {
                     event.setCancelled(true);
                     event.setDamage(0);

--- a/src/main/java/net/vertrauterdavid/listener/PlayerJoinListener.java
+++ b/src/main/java/net/vertrauterdavid/listener/PlayerJoinListener.java
@@ -10,11 +10,17 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 
+import java.util.Objects;
+
 public class PlayerJoinListener implements Listener {
 
     @EventHandler
     public void handle(PlayerJoinEvent event) {
         Player player = event.getPlayer();
+
+        if (player.hasPermission(Objects.requireNonNull(EventCore.getInstance().getConfig().getString("Settings.HostRank.Permission"),"event.host"))) {
+            Bukkit.dispatchCommand(Bukkit.getConsoleSender(), Objects.requireNonNull(EventCore.getInstance().getConfig().getString("Settings.HostRank.JoinCommand").replaceAll("%player%", player.getName()), "event.host"));
+        }
 
         if (EventCore.getInstance().getConfig().getBoolean("Messages.PlayerJoin.Enabled")) {
             event.setJoinMessage(MessageUtil.getPrefix() + MessageUtil.get("Messages.PlayerJoin.Message").replaceAll("%player%", player.getName()));

--- a/src/main/java/net/vertrauterdavid/listener/PlayerQuitListener.java
+++ b/src/main/java/net/vertrauterdavid/listener/PlayerQuitListener.java
@@ -2,16 +2,23 @@ package net.vertrauterdavid.listener;
 
 import net.vertrauterdavid.EventCore;
 import net.vertrauterdavid.util.MessageUtil;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerQuitEvent;
+
+import java.util.Objects;
 
 public class PlayerQuitListener implements Listener {
 
     @EventHandler
     public void handle(PlayerQuitEvent event) {
         Player player = event.getPlayer();
+
+        if (player.hasPermission(Objects.requireNonNull(EventCore.getInstance().getConfig().getString("Settings.HostRank.Permission"),"event.host"))) {
+            Bukkit.dispatchCommand(Bukkit.getConsoleSender(), Objects.requireNonNull(EventCore.getInstance().getConfig().getString("Settings.HostRank.QuitCommand").replaceAll("%player%", player.getName()), "event.host"));
+        }
 
         if (EventCore.getInstance().getConfig().getBoolean("Messages.PlayerQuit.Enabled")) {
             event.setQuitMessage(MessageUtil.getPrefix() + MessageUtil.get("Messages.PlayerQuit.Message").replaceAll("%player%", player.getName()));

--- a/src/main/java/net/vertrauterdavid/util/BorderUtil.java
+++ b/src/main/java/net/vertrauterdavid/util/BorderUtil.java
@@ -8,7 +8,7 @@ public class BorderUtil implements Runnable {
     public static double borderDamageBuffer = 0.0;
     public static double borderDamageAmount = 0.2;
     public static int lastOptimal = borderDefault;
-    public static boolean autoBorder = true;
+    public static boolean autoBorder = EventCore.getInstance().getConfig().getBoolean("Settings.WorldBorder.AutoBorder", false);
 
     public BorderUtil() {
         borderDefault = EventCore.getInstance().getConfig().getInt("Settings.WorldBorder.DefaultSize", borderDefault);

--- a/src/main/java/net/vertrauterdavid/util/BorderUtil.java
+++ b/src/main/java/net/vertrauterdavid/util/BorderUtil.java
@@ -17,6 +17,13 @@ public class BorderUtil implements Runnable {
         lastOptimal = borderDefault;
     }
 
+    public static void setAutoBorder(boolean value) {
+        autoBorder = value;
+        EventCore.getInstance().getConfig().set("Settings.WorldBorder.AutoBorder", value);
+        EventCore.getInstance().saveConfig();
+    }
+
+
     @Override
     public void run() {
         if (EventCore.getInstance().getGameManager().isRunning() && autoBorder) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -19,7 +19,12 @@ Settings:
   MaxBuildHeight: 300 # Maximum build height
   DisableFallDamage: true # Disable fall damage
   DisableItemExplosions: true # Disable item explosions for End Crystal
+  HostRank:
+    Permission: "event.host" # Permission which is required to receive the host rank upon Join
+    JoinCommand: "lp user %player% parent add host"
+    QuitCommand: "lp user %player% parent remove host"
   WorldBorder:
+    AutoBorder: false # Change the default value of the AutoBorder feature
     DefaultSize: 200 # Default size before and after the event
     DisableEnderPeals: true # Disable EnderPeals outside the world border
     Boost: # Boost players who are outside the border into the border

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,8 +1,8 @@
 name: EventCore
-version: 1.5
-api-version: 1.19
+version: 1.6
+api-version: 1.21
 main: net.vertrauterdavid.EventCore
-author: VertrauterDavid
+author: VertrauterDavid, JavaMio
 website: https://vertrauterdavid.net/ & https://github.com/vertrauterdavid/
 
 softdepend: [PlaceholderAPI]
@@ -14,4 +14,5 @@ commands:
   e:
   kit:
   revive:
+  respawn:
   spawn:


### PR DESCRIPTION
This pull request primarily introduces a host rank feature. Players who join the server with a specific permission will automatically receive the host rank, which will be removed again when they leave.

Additionally, the plugin has been updated to support newer Minecraft versions, and more configuration options have been added - including the ability to toggle AutoBorder directly to on or off as default.